### PR TITLE
fix: update deprecated release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: 🚀 Run Release Please
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
           
       - name: 📦 Setup Node.js (if release created)
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
- Updates deprecated `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4`
- Resolves deprecation warning shown in GitHub Actions workflow logs
- Should fix the "tag already exists" error by using the actively maintained action

## Problem
The release-please GitHub Action was failing with:
- Deprecation warning: `google-github-actions/release-please-action is deprecated`
- Tag conflict error: `Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`

## Solution
Switch to the new maintained action `googleapis/release-please-action@v4` which should handle tag conflicts better and eliminate the deprecation warning.

## Test plan
- [x] Verify the workflow file syntax is correct
- [ ] Test that the updated action runs without deprecation warnings
- [ ] Confirm tag versioning works properly after merge

🤖 Generated with [Claude Code](https://claude.ai/code)